### PR TITLE
Fix rails migration templates for Rails 8

### DIFF
--- a/lib/generators/rodauth/oauth/templates/db/migrate/create_rodauth_oauth.rb
+++ b/lib/generators/rodauth/oauth/templates/db/migrate/create_rodauth_oauth.rb
@@ -136,7 +136,7 @@ class CreateRodauthOauth < ActiveRecord::Migration<%= migration_version %>
       t.boolean :check_idp_cert_expiration, null: true
       t.text :name_identifier_format, null: true
       t.string :audience, null: true
-      t.string :issuer, null: false, unique: true
+      t.string :issuer, null: false, index: { unique: true }
     end
 
     create_table :oauth_dpop_proofs, primary_key: :jti do |t|

--- a/lib/generators/rodauth/oauth/templates/db/migrate/create_rodauth_oauth.rb
+++ b/lib/generators/rodauth/oauth/templates/db/migrate/create_rodauth_oauth.rb
@@ -139,7 +139,8 @@ class CreateRodauthOauth < ActiveRecord::Migration<%= migration_version %>
       t.string :issuer, null: false, index: { unique: true }
     end
 
-    create_table :oauth_dpop_proofs, primary_key: :jti do |t|
+    create_table :oauth_dpop_proofs, id: false, primary_key: :jti do |t|
+      t.string :jti, null: false
       t.datetime :first_use, null: false, default: -> { "CURRENT_TIMESTAMP(6)" }
     end
   end

--- a/lib/generators/rodauth/oauth/templates/db/migrate/create_rodauth_oauth.rb
+++ b/lib/generators/rodauth/oauth/templates/db/migrate/create_rodauth_oauth.rb
@@ -140,7 +140,6 @@ class CreateRodauthOauth < ActiveRecord::Migration<%= migration_version %>
     end
 
     create_table :oauth_dpop_proofs, primary_key: :jti do |t|
-      t.string :jti, null: false
       t.datetime :first_use, null: false, default: -> { "CURRENT_TIMESTAMP(6)" }
     end
   end


### PR DESCRIPTION
Having just tried to stand this project up in a new Rails 8 application the migration threw a couple of exceptions at me: 
```
-- create_table(:oauth_saml_settings)
bin/rails aborted!
StandardError: An error has occurred, this and all later migrations canceled: (StandardError)

Unknown key: :unique. Valid keys are: :limit, :precision, :scale, :default, :null, :collation, :comment, :primary_key, :if_exists, :if_not_exists, :array, :using, :cast_as, :as, :type, :enum_type, :stored
```
Related to the missing `index` method, which then passes the unique constraint as a hash

```
ArgumentError: you can't redefine the primary key column 'jti' on 'oauth_dpop_proofs'. To define a custom primary key, pass { id: false } to create_table. (ArgumentError)

              raise ArgumentError, "you can't redefine the primary key column '#{name}' on '#{@name}'. To define a custom primary key, pass { id: false } to create_table."
```
I've changed this to specify `id: false` in order to allow the manual configuration of the PK
